### PR TITLE
Feat: Add filtering message by createdAt after restoring connection

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -81,7 +81,7 @@ export class Channel<
   lastTypingEvent: Date | null;
   isTyping: boolean;
   disconnected: boolean;
-  messageFilters: MessagePaginationOptions | undefined;
+  messageFilters?: MessagePaginationOptions;
 
   /**
    * constructor - Create a channel

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -49,6 +49,7 @@ import {
   UserResponse,
 } from './types';
 import { Role } from './permissions';
+import { MessagePaginationOptions } from 'index';
 
 /**
  * Channel - The Channel class manages it's own state.
@@ -80,6 +81,7 @@ export class Channel<
   lastTypingEvent: Date | null;
   isTyping: boolean;
   disconnected: boolean;
+  messageFilters: MessagePaginationOptions | undefined;
 
   /**
    * constructor - Create a channel
@@ -789,6 +791,7 @@ export class Channel<
 
     const combined = { ...defaultOptions, ...options };
     const state = await this.query(combined);
+    this.messageFilters = combined.messages;
     this.initialized = true;
     this.data = state.channel;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,7 +28,7 @@ export const APIErrorCodes: Record<string, { name: string; retryable: boolean }>
   '99': { name: 'AppSuspendedError', retryable: false },
 };
 
-type APIError = Error & { code: number; isWSFailure?: boolean };
+export type APIError = Error & { code: number; isWSFailure?: boolean };
 
 export function isAPIError(error: Error): error is APIError {
   return (error as APIError).code !== undefined;


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
After restoring the connection, the messages in the current session were not cleared - on restore connection we do not pass anything as stateOptions, so skill initialization was undefined, so it was not cleared - and as the result, they were duplicated.
Also, I have added storing message filters when we start watching a chat and it can be used (ex. created_at_after) after restoring connection to filter out messages that were sent before a user has joined the chat.

## Changelog

-
